### PR TITLE
Remoção do Window.history.replaceState

### DIFF
--- a/src/scenes/Welcome/Welcome.tsx
+++ b/src/scenes/Welcome/Welcome.tsx
@@ -8,7 +8,6 @@ import './Welcome.css';
 
 function Welcome() {
   const navigate = useNavigate();
-  //window.history.replaceState({}, 'Dom Que Shot!', 'https://www.domqueshot.com/'); //TODO uncomment this when putting in production
 
   useEffect(() => {
     const userData = JSON.parse(window.localStorage.getItem('userData'));

--- a/src/scenes/Welcome/Welcome.tsx
+++ b/src/scenes/Welcome/Welcome.tsx
@@ -8,7 +8,7 @@ import './Welcome.css';
 
 function Welcome() {
   const navigate = useNavigate();
-  //window.history.replaceState({}, 'Dom Que Shot!', 'http://localhost:5173'); //TODO uncomment this when tests are over
+  //window.history.replaceState({}, 'Dom Que Shot!', 'https://www.domqueshot.com/'); //TODO uncomment this when putting in production
 
   useEffect(() => {
     const userData = JSON.parse(window.localStorage.getItem('userData'));


### PR DESCRIPTION
Neste PR:
> Literalmente removida a linha de código que configura o endereço aparente no navegador para um texto específico. Esta linha não é mais necessária.