### PR TITLE
Added automatic reload if reconnection happens outside of Lobby

### DIFF
--- a/src/lib/socket.ts
+++ b/src/lib/socket.ts
@@ -74,7 +74,7 @@ class SocketConnection {
   static getInstance(isLobby = false) {
     if (!SocketConnection.instance) {
       if (!isLobby) {
-        alert('Conexão perdida! Reconectando...');
+        alert('Conexão perdida! Reconectando...'); //TODO: remover alerta antes da release do Beta
         window.location.reload();
       }
       SocketConnection.instance = new SocketConnection();

--- a/src/lib/socket.ts
+++ b/src/lib/socket.ts
@@ -71,8 +71,12 @@ class SocketConnection {
 
   //abaixo, as funções originalmente desenvolvidas pelo Carlos para esta classe
 
-  static getInstance() {
+  static getInstance(isLobby = false) {
     if (!SocketConnection.instance) {
+      if (!isLobby) {
+        alert('Conexão perdida! Reconectando...');
+        window.location.reload();
+      }
       SocketConnection.instance = new SocketConnection();
     }
     return SocketConnection.instance;

--- a/src/scenes/Lobby/Lobby.tsx
+++ b/src/scenes/Lobby/Lobby.tsx
@@ -50,7 +50,7 @@ export default function Lobby() {
 
   //SOCKET///////////////////////////////////////////////////////////////////////////////////////
 
-  const socket = SocketConnection.getInstance();
+  const socket = SocketConnection.getInstance(true);
 
   useEffect(() => {
     socket.connect();


### PR DESCRIPTION
Neste PR:

- Implementada a verificação de conexão com socket que ocorre fora do Lobby (quando um jogador cai durante uma partida)
- Coloquei um alert que é inteiramente opcional, mas queria testar com outros aparelhos antes de retirá-lo do código. 