### PR TITLE
Bugfix - Tela de escolher avatar

### DIFF
--- a/src/scenes/ChooseAvatar/ChooseAvatar.tsx
+++ b/src/scenes/ChooseAvatar/ChooseAvatar.tsx
@@ -29,6 +29,31 @@ function ChooseAvatar() {
     visibility: 'hidden',
   });
 
+  //SOCKET///////////////////////////////////////////////////////////////////////////////////////
+
+  const socket = SocketConnection.getInstance();
+
+  useEffect(() => {
+    socket.connect();
+    console.log(socket);
+    socket.addEventListener('room-is-moving-to', (destination) => {
+      if (destination === '/SelectNextGame') {
+        console.log(`Movendo a sala para ${destination}.`);
+        return navigate(destination);
+      }
+    });
+
+    return () => {
+      console.log('saindo da tela chooseAvatar (return do useEffect)');
+      console.log(socket);
+      if(socket.socket){                    //paliativo. Socket.socket não deveria estar indefinido aqui,
+        socket.removeAllListeners();        //mas por algum motivo fica quando o usuário está no chooseAvatar e decide sair da sala (voltar pra tela Home)
+      }                                     //quando o usuário decide voltar pro lobby (continua na sala), o problema não acontece. Vai entender.
+    };
+  }, []);
+
+  //////////////////////////////////////////////////////////////////////////////////////////////
+
   useEffect(() => {
     if (userData.nickname) {
       setUserName(userData.nickname);
@@ -146,8 +171,9 @@ function ChooseAvatar() {
   ////////////////////////////////////////////////////////////////////////////////////////////////
 
   const leaveMatch = () => {
-    const socket = SocketConnection.getInstance();
-    socket.disconnect();
+    if(socket){
+      socket.disconnect();
+    }
     navigate('/Home');
   };
 

--- a/src/scenes/ChooseAvatar/ChooseAvatar.tsx
+++ b/src/scenes/ChooseAvatar/ChooseAvatar.tsx
@@ -46,7 +46,7 @@ function ChooseAvatar() {
     return () => {
       console.log('saindo da tela chooseAvatar (return do useEffect)');
       console.log(socket);
-      if(socket.socket){                    //paliativo. Socket.socket não deveria estar indefinido aqui,
+      if(socket.socket){                    //TODO: paliativo. Socket.socket não deveria estar indefinido aqui,
         socket.removeAllListeners();        //mas por algum motivo fica quando o usuário está no chooseAvatar e decide sair da sala (voltar pra tela Home)
       }                                     //quando o usuário decide voltar pro lobby (continua na sala), o problema não acontece. Vai entender.
     };

--- a/src/scenes/ChooseAvatar/ChooseAvatar.tsx
+++ b/src/scenes/ChooseAvatar/ChooseAvatar.tsx
@@ -44,11 +44,9 @@ function ChooseAvatar() {
     });
 
     return () => {
-      console.log('saindo da tela chooseAvatar (return do useEffect)');
-      console.log(socket);
-      if(socket.socket){                    //TODO: paliativo. Socket.socket não deveria estar indefinido aqui,
-        socket.removeAllListeners();        //mas por algum motivo fica quando o usuário está no chooseAvatar e decide sair da sala (voltar pra tela Home)
-      }                                     //quando o usuário decide voltar pro lobby (continua na sala), o problema não acontece. Vai entender.
+      if(socket.socket){      
+        socket.removeAllListeners();   
+      }                      
     };
   }, []);
 
@@ -171,9 +169,7 @@ function ChooseAvatar() {
   ////////////////////////////////////////////////////////////////////////////////////////////////
 
   const leaveMatch = () => {
-    if(socket){
-      socket.disconnect();
-    }
+    socket && socket.disconnect();
     navigate('/Home');
   };
 


### PR DESCRIPTION
Neste PR:

> corrigido o problema de o jogador na tela de avatar não ser puxado para a tela de roleta quando o jogo recomeça. Ou seja, ele só é puxado se já estivesse na sala e a partida tivesse voltado para o lobby momentaneamente. Se ele está entrando na sala pela primeira vez, não é puxado automaticamente.

Bugs conhecidos:

> Por algum raio de motivo o socket fica indefinido quando o jogador decide, a partir da tela de escolher avatar, sair da sala (voltar para HOME). Quando ele decide finalizar as mudanças e voltar para o Lobby, no entanto, tudo transcorre normalmente. Consegui resolver isso com uma 'gambiarra' mas não acredito que seja a melhor solução.