### PR TITLE
Extra - código da sala agora visível em diversas telas

### DIFF
--- a/src/components/Game/Cover/index.tsx
+++ b/src/components/Game/Cover/index.tsx
@@ -42,9 +42,10 @@ export default function CoverPage({
     <Header
       goBackArrow={goBackPage}
       infoPage={() => setPopupVisibility(true)}
+      roomCode
     />
   ) : (
-    <Header infoPage={() => setPopupVisibility(true)} />
+    <Header infoPage={() => setPopupVisibility(true)} roomCode/>
   );
 
   const coverCard = useRef();

--- a/src/components/Game/Cover/index.tsx
+++ b/src/components/Game/Cover/index.tsx
@@ -152,6 +152,7 @@ export default function CoverPage({
   return (
     <Background>
       <Popup
+        type='info'
         height={sizeOfDescription ? sizeOfDescription : undefined}
         title={title}
         description={description}

--- a/src/components/Game/Hint/index.tsx
+++ b/src/components/Game/Hint/index.tsx
@@ -21,7 +21,7 @@ export default function HintPage({
 }: HintProps) {
   return (
     <Background>
-      <Header logo={coverImg} goBackArrow={coverPage} title={title} />
+      <Header roomCode logo={coverImg} goBackArrow={coverPage} title={title} />
       <HintPageDiv>
         <HintPageDescription>{description}</HintPageDescription>
         <Button staysOnBottom onClick={gamePage}>

--- a/src/components/Header/Header.style.ts
+++ b/src/components/Header/Header.style.ts
@@ -29,6 +29,20 @@ export const Title = styled.p`
   margin: 0;
 `;
 
+export const RoomCodeDiv = styled.div`
+  margin-right: 15px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: auto;
+  height: auto;
+`;
+
+export const RoomCode = styled.p`
+  font-size: 16px;
+  color: #524b6e;
+`;
+
 export const Timer = styled.div`
   align-self: center;
   color: red;

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -14,12 +14,15 @@ import {
   LogoDiv,
   LogoBackground,
   Logo,
+  RoomCodeDiv,
+  RoomCode,
 } from './Header.style';
 
 interface HeaderProps {
   logo?: boolean | string;
   title?: string;
   goBackArrow?: true | (() => void);
+  roomCode?: boolean,
   timer?: number;
   settingsPage?: string | (() => void);
   infoPage?: string | (() => void);
@@ -29,6 +32,7 @@ export default function Header({
   logo,
   title,
   goBackArrow,
+  roomCode,
   timer,
   settingsPage,
   infoPage,
@@ -66,6 +70,15 @@ export default function Header({
     settingsPage();
   };
 
+  const getRoomCode = () => {
+    const userData = JSON.parse(window.localStorage.getItem('userData'));
+    try {
+      return userData.roomCode;
+    } catch (e) {
+      return undefined;
+    }
+  }
+
   return (
     <HeaderDiv>
       <ArrowAndTitle>
@@ -83,6 +96,10 @@ export default function Header({
       </Timer>
 
       <SettingsInfoAndLogo>
+        <RoomCodeDiv style={roomCode ? {} : { display: 'none' }}>
+          <RoomCode>Sala:<br/>{getRoomCode()}</RoomCode>
+        </RoomCodeDiv>
+
         <InfoDiv style={infoPage ? {} : { display: 'none' }}>
           <Info
             color="#FBBC05"

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useGlobalContext } from '../../contexts/GlobalContextProvider';
 import { ArrowLeft, Info, Settings } from 'react-feather';
 import { useNavigate } from 'react-router-dom';
 import DomQueShotLogo from '../../assets/logo-darker.png';
@@ -39,6 +40,7 @@ export default function Header({
   settingsPage,
   infoPage,
 }: HeaderProps) {
+  const { room } = useGlobalContext();
   const navigateTo = useNavigate();
   const [warningVisibility, setWarningVisibility] = useState<boolean>(false);
 
@@ -73,17 +75,8 @@ export default function Header({
     settingsPage();
   };
 
-  const getRoomCode = () => {
-    const userData = JSON.parse(window.localStorage.getItem('userData'));
-    try {
-      return userData.roomCode;
-    } catch (e) {
-      return undefined;
-    }
-  }
-
   const copyCode = () => {
-    navigator.clipboard.writeText(getRoomCode());
+    navigator.clipboard.writeText(room.code);
     setWarningVisibility(true);
     setTimeout(() => {
       setWarningVisibility(false);
@@ -117,7 +110,7 @@ export default function Header({
 
       <SettingsInfoAndLogo>
         <RoomCodeDiv onClick={copyCode} style={roomCode ? {} : { display: 'none' }}>
-          <RoomCode>Sala:<br/>{getRoomCode()}</RoomCode>
+          <RoomCode>Sala:<br/>{room.code}</RoomCode>
         </RoomCodeDiv>
 
         <InfoDiv style={infoPage ? {} : { display: 'none' }}>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,6 +1,8 @@
+import { useState } from 'react';
 import { ArrowLeft, Info, Settings } from 'react-feather';
 import { useNavigate } from 'react-router-dom';
 import DomQueShotLogo from '../../assets/logo-darker.png';
+import Popup from '../Popup';
 import {
   ArrowDiv,
   ArrowAndTitle,
@@ -38,6 +40,7 @@ export default function Header({
   infoPage,
 }: HeaderProps) {
   const navigateTo = useNavigate();
+  const [warningVisibility, setWarningVisibility] = useState<boolean>(false);
 
   const seconds = timer / 1000;
   const timerColor = seconds < 3 ? 'red' : 'white';
@@ -79,8 +82,25 @@ export default function Header({
     }
   }
 
+  const copyCode = () => {
+    navigator.clipboard.writeText(getRoomCode());
+    setWarningVisibility(true);
+    setTimeout(() => {
+      setWarningVisibility(false);
+    }, 2000);
+  }
+
+  
+
   return (
     <HeaderDiv>
+      {roomCode && (
+      <Popup
+        type = 'warning'
+        warningType='success'
+        description={'código da sala copiado!'}
+        show={warningVisibility}
+      />)}
       <ArrowAndTitle>
         <ArrowDiv style={goBackArrow ? {} : { display: 'none' }}>
           <ArrowLeft width="30px" height="30px" onClick={goToPreviousPage} />
@@ -96,7 +116,7 @@ export default function Header({
       </Timer>
 
       <SettingsInfoAndLogo>
-        <RoomCodeDiv style={roomCode ? {} : { display: 'none' }}>
+        <RoomCodeDiv onClick={copyCode} style={roomCode ? {} : { display: 'none' }}>
           <RoomCode>Sala:<br/>{getRoomCode()}</RoomCode>
         </RoomCodeDiv>
 

--- a/src/components/Popup/Popup.css
+++ b/src/components/Popup/Popup.css
@@ -4,7 +4,8 @@
   padding: 20px 20px 0 20px;
   width: 360px;
   border-radius: 15px;
-  background: rgba(255, 255, 255, 0.95);
+  background: rgba(255, 255, 255);
+  opacity: 0.95;
 }
 
 .PopupHeader {
@@ -20,6 +21,8 @@
 }
 
 .PopupDescription {
+  display: flex;
+  justify-content: space-between;
   color: black;
   font-family: 'Roboto';
   font-size: 18px;

--- a/src/components/Popup/index.tsx
+++ b/src/components/Popup/index.tsx
@@ -1,20 +1,25 @@
-import { X } from 'react-feather';
+import { useEffect, useRef } from 'react';
+import { X, CheckCircle, AlertTriangle, XCircle } from 'react-feather';
 import gsap from 'gsap';
 import './Popup.css';
 
 interface PopupProps {
+  type: 'info' | 'warning';
+  warningType?: 'success' | 'alert' | 'failure';
   height?: number;
-  title: string;
+  title?: string;
   description: JSX.Element | string;
   show: boolean;
   comesFromTop?: boolean;
   titleColor?: string;
   descriptionColor?: string;
   backgroundColor?: string;
-  exit: () => void;
+  exit?: () => void;
 }
 
 export default function Popup({
+  type,
+  warningType,
   height,
   title,
   description,
@@ -25,6 +30,10 @@ export default function Popup({
   backgroundColor,
   exit,
 }: PopupProps) {
+
+  const infoRef = useRef();
+  const warningRef = useRef();
+
   const releaseProps = comesFromTop
     ? {
         scale: 1,
@@ -54,40 +63,67 @@ export default function Popup({
       };
 
   const releasePopup = () => {
-    gsap.to('.PopupContainer', releaseProps);
+    const ref = (type === 'info')? infoRef : warningRef;
+    gsap.to( ref.current, releaseProps);
   };
 
   const hidePopup = () => {
-    gsap.to('.PopupContainer', hideProps);
+    const ref = (type === 'info')? infoRef : warningRef;
+    gsap.to( ref.current, hideProps);
   };
 
-  if (show === true) {
-    releasePopup();
-  } else {
-    hidePopup();
-  }
+  useEffect(() => {
+    if (show === true) {
+      releasePopup();
+    } else {
+      hidePopup();
+    }
+  }, [show])
 
   const popupStyle = {
     height: height ? `${height}px` : 'auto',
-    backgroundColor: backgroundColor ? backgroundColor : '#ffffff',
-    opacity: 0.95,
+    backgroundColor: (backgroundColor)? backgroundColor : '#ffffff',
+    paddingTop: (title)? '20px' : 0,
   };
 
-  return (
-    <div className={`PopupContainer ${comesFromTop ? 'Top' : 'Bottom'}`}>
-      <div className="PopupDiv" style={popupStyle}>
-        <div className="PopupHeader">
-          <p
-            className="PopupTitle"
-            style={titleColor ? { color: titleColor } : {}}>
-            {title}
-          </p>
-          <X color="#170C32" width="24px" strokeWidth="5px" onClick={exit} />
+  const getIcon = () => {
+    switch(warningType){
+      case 'success': return <CheckCircle color="lime" width={24} height={24}/>
+      case 'alert': return <AlertTriangle color='gold' width={24} height={24}/>
+      case 'failure': return <XCircle color='red' width={24} height={24}/>
+      default: return null;
+    }
+  }
+
+  if(type === 'info'){
+    return (
+      <div ref={infoRef} className={`PopupContainer ${comesFromTop ? 'Top' : 'Bottom'}`}>
+        <div className="PopupDiv" style={popupStyle}>
+          <div className="PopupHeader">
+            <p
+              className="PopupTitle"
+              style={titleColor ? { color: titleColor } : {}}>
+              {title}
+            </p>
+            <X color="#170C32" width="24px" strokeWidth="5px" onClick={exit} />
+          </div>
+          <div
+            className="PopupDescription"
+            style={descriptionColor ? { color: descriptionColor } : {}}>
+            {description}
+          </div>
         </div>
+      </div>
+    );
+  } 
+  return (
+    <div ref={warningRef} className={`PopupContainer Bottom`}>
+      <div className="PopupDiv" style={popupStyle}>
         <div
           className="PopupDescription"
           style={descriptionColor ? { color: descriptionColor } : {}}>
           {description}
+          {getIcon()}
         </div>
       </div>
     </div>

--- a/src/scenes/EuNunca/Game/index.tsx
+++ b/src/scenes/EuNunca/Game/index.tsx
@@ -32,7 +32,7 @@ export default function GamePage({
   if (turnVisibility === true) {
     return (
       <Background>
-        <Header logo={coverImg} />
+        <Header roomCode logo={coverImg} />
         <div className="EuNuncaDiv">
           <div className="EuNuncaTitleAndSuggestions">
             <p className="EuNuncaGameTitle">
@@ -60,7 +60,7 @@ export default function GamePage({
 
   return (
     <Background>
-      <Header logo={coverImg} />
+      <Header roomCode logo={coverImg} />
       <div className="WhoDrankContainer" style={{ marginTop: '3em' }}>
         <AwaitingBanner
           icon={glassIcon}

--- a/src/scenes/Home/Home.tsx
+++ b/src/scenes/Home/Home.tsx
@@ -150,6 +150,7 @@ function Home() {
       </div>
 
       <Popup
+        type='info'
         height={280}
         title={gameInfo.title}
         description={gameInfo.description}

--- a/src/scenes/QuemSouEu/Category/Category.tsx
+++ b/src/scenes/QuemSouEu/Category/Category.tsx
@@ -60,6 +60,7 @@ export default function CategoryPage({
     return (
       <Background noImage>
         <Popup
+          type='info'
           title={title}
           description={description}
           show={popupVisibility}
@@ -97,6 +98,7 @@ export default function CategoryPage({
   return (
     <Background>
       <Popup
+        type='info'
         title={title}
         description={description}
         show={popupVisibility}

--- a/src/scenes/QuemSouEu/Category/Category.tsx
+++ b/src/scenes/QuemSouEu/Category/Category.tsx
@@ -66,7 +66,7 @@ export default function CategoryPage({
           exit={() => setPopupVisibility(false)}
           comesFromTop
         />
-        <Header infoPage={() => setPopupVisibility(true)} />
+        <Header roomCode infoPage={() => setPopupVisibility(true)} />
         <CategoryDiv>
           <Content>
             <Title>Escolha uma categoria para o grupo:</Title>
@@ -104,6 +104,7 @@ export default function CategoryPage({
         comesFromTop
       />
       <Header
+        roomCode
         infoPage={() => {
           setPopupVisibility(true);
         }}

--- a/src/scenes/QuemSouEu/Game/Game.tsx
+++ b/src/scenes/QuemSouEu/Game/Game.tsx
@@ -133,7 +133,7 @@ export default function GamePage({
         exit={() => setPopupVisibility(false)}
         comesFromTop
       />
-      <Header infoPage={() => setPopupVisibility(true)} />
+      <Header roomCode infoPage={() => setPopupVisibility(true)} />
       {turnVisibility === true ? alert : null}
       <GameDiv>
         <Content>

--- a/src/scenes/QuemSouEu/Game/Game.tsx
+++ b/src/scenes/QuemSouEu/Game/Game.tsx
@@ -127,6 +127,7 @@ export default function GamePage({
   return (
     <Background noImage>
       <Popup
+        type='info'
         title={title}
         description={description}
         show={popupVisibility}

--- a/src/scenes/SelectNextGame/SelectNextGame.tsx
+++ b/src/scenes/SelectNextGame/SelectNextGame.tsx
@@ -222,9 +222,9 @@ export default function SelectNextGame() {
 
   const header =
     ownerVisibility === Visibility.Visible ? (
-      <Header goBackArrow={backToLobby} logo />
+      <Header goBackArrow={backToLobby} roomCode logo />
     ) : (
-      <Header logo />
+      <Header roomCode logo />
     );
 
   return (

--- a/src/scenes/WhoDrank/WhoDrank.tsx
+++ b/src/scenes/WhoDrank/WhoDrank.tsx
@@ -89,7 +89,7 @@ export default function WhoDrankPage() {
     });
   };
 
-  const header = coverImg ? <Header logo={coverImg} /> : <Header logo />;
+  const header = coverImg ? <Header roomCode logo={coverImg} /> : <Header roomCode logo />;
 
   if (turnVisibility === true) {
     return (


### PR DESCRIPTION
Neste PR:

> O código da sala passa a ser visível em quase todas as telas, de modo a facilitar que pessoas de fora entrem no jogo enquanto a partida está em andamento. Só não incluí nas telas em que novos jogadores não podem entrar no meio, como durante o bang bang e nas telas de resultado.
> Ao clicar no código, o usuário copia para a área de transferência. Um pequeno popup aparece para confirmar (é necessário estar no localhost ou em uma conexão https para isso. Acessos diretamente pelo IP não funcionam). 

Bugs conhecidos:

> Nenhum.