### PR TITLE
Extra - desabilitada tradução automática

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" translate="no">
   <head>
     <meta charset="UTF-8" />
+    <meta name="google" content="notranslate">
     <link rel="icon" type="image/png" href="/logo-icon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
Neste PR:

> Desabilitada a solicitação irritante de traduzir a página que fica brotando frequentemente quando a página é acessada pela primeira vez ou recarregada.

Bugs conhecidos:

> Nenhum.